### PR TITLE
Improvements in subscription manager

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,13 +1,5 @@
-locals_without_parens = [
-  app_env: 3,
-  app_env: 4
-]
-
 [
-  inputs: ["mix.exs", "{lib,test}/**/*.{ex,exs}"],
-  line_length: 80,
-  locals_without_parens: locals_without_parens,
-  export: [
-    locals_without_parens: locals_without_parens
-  ]
+  import_deps: [:skogsra],
+  inputs: ["{mix,.formatter}.exs", "{lib,test}/**/*.{ex,exs}"],
+  line_length: 80
 ]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,7 +36,7 @@ jobs:
         run: mix do local.rebar --force, local.hex --force, deps.get
       - name: "Compile dependencies"
         run: mix deps.compile
-      - name: "Compile ExReg"
+      - name: "Compile Yggdrasil"
         run: mix compile --warnings-as-errors
       - name: "Check formatting"
         run: mix format --dry-run --check-formatted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v6.0.1
+
+### Enhancements
+
+  * Updated `Yggdrasil.Subscriber.Manager` so it starts faster.
+
 ## v6.0.0
 
 ### Enhancements

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-config :logger, level: :error

--- a/lib/yggdrasil/subscriber/distributor.ex
+++ b/lib/yggdrasil/subscriber/distributor.ex
@@ -56,12 +56,7 @@ defmodule Yggdrasil.Subscriber.Distributor do
     children = [
       %{
         id: Manager,
-        start: {Manager, :start_link, [channel, [name: manager_name]]},
-        restart: :transient
-      },
-      %{
-        id: Task,
-        start: {Task, :start_link, [fn -> Manager.add(channel, pid) end]},
+        start: {Manager, :start_link, [channel, pid, [name: manager_name]]},
         restart: :transient
       },
       %{

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Yggdrasil.Mixfile do
   use Mix.Project
 
-  @version "6.0.0"
+  @version "6.0.1"
   @root "https://github.com/gmtprime/yggdrasil"
 
   def project do

--- a/test/yggdrasil/subscriber/adapter_test.exs
+++ b/test/yggdrasil/subscriber/adapter_test.exs
@@ -14,8 +14,7 @@ defmodule Yggdrasil.Subscriber.AdapterTest do
     publisher = ExReg.local({Publisher, channel})
     manager = ExReg.local({Manager, channel})
     assert {:ok, _} = Publisher.start_link(channel, name: publisher)
-    assert {:ok, _} = Manager.start_link(channel, name: manager)
-    :ok = Manager.add(channel, self())
+    assert {:ok, _} = Manager.start_link(channel, self(), name: manager)
 
     assert {:ok, adapter} = Adapter.start_link(channel)
     assert_receive {:Y_CONNECTED, _}, 500
@@ -31,8 +30,7 @@ defmodule Yggdrasil.Subscriber.AdapterTest do
     publisher = ExReg.local({Publisher, channel})
     manager = ExReg.local({Manager, channel})
     assert {:ok, _} = Publisher.start_link(channel, name: publisher)
-    assert {:ok, _} = Manager.start_link(channel, name: manager)
-    :ok = Manager.add(channel, self())
+    assert {:ok, _} = Manager.start_link(channel, self(), name: manager)
 
     assert {:ok, adapter} = Adapter.start_link(channel)
     assert_receive {:Y_CONNECTED, ^channel}, 500

--- a/test/yggdrasil/subscriber/manager_test.exs
+++ b/test/yggdrasil/subscriber/manager_test.exs
@@ -3,388 +3,10 @@ defmodule Yggdrasil.Subscriber.ManagerTest do
 
   alias Yggdrasil.Subscriber.Manager
 
-  describe "join/2" do
-    setup do
-      {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
-      cache = :ets.new(:test, [:set])
-
-      {:ok, channel: channel, cache: cache}
-    end
-
-    test "joins to connected group when connected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :connected,
-        cache: cache
-      }
-
-      name = {:connected, channel}
-      pid = self()
-
-      assert :ok = Manager.join([pid], state)
-      assert_receive {:Y_CONNECTED, ^channel}
-      assert pid in :pg.get_members(Yggdrasil.Subscriber.Manager, name)
-      assert [{^pid, reference}] = :ets.lookup(cache, pid)
-      assert is_reference(reference)
-    end
-
-    test "joins once when connected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :connected,
-        cache: cache
-      }
-
-      pid = self()
-
-      assert :ok = Manager.join([pid], state)
-      assert :ok = Manager.join([pid], state)
-
-      assert [{^pid, _}] = :ets.lookup(cache, pid)
-    end
-
-    test "joins to disconnected group when disconnected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :disconnected,
-        cache: cache
-      }
-
-      name = {:disconnected, channel}
-      pid = self()
-
-      assert :ok = Manager.join([pid], state)
-      assert pid in :pg.get_members(Yggdrasil.Subscriber.Manager, name)
-      assert [{^pid, reference}] = :ets.lookup(cache, pid)
-      assert is_reference(reference)
-    end
-
-    test "joins once when disconnected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :disconnected,
-        cache: cache
-      }
-
-      pid = self()
-
-      assert :ok = Manager.join([pid], state)
-      assert :ok = Manager.join([pid], state)
-
-      assert [{^pid, _}] = :ets.lookup(cache, pid)
-    end
-  end
-
-  describe "leave/2" do
-    setup do
-      {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
-      cache = :ets.new(:test, [:set])
-
-      {:ok, channel: channel, cache: cache}
-    end
-
-    test "leaves from connected group when connected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :connected,
-        cache: cache
-      }
-
-      name = {:connected, channel}
-      pid = self()
-      :ok = Manager.join([pid], state)
-
-      assert :ok = Manager.leave([pid], state)
-      assert_receive {:Y_DISCONNECTED, ^channel}
-      assert pid not in :pg.get_members(Yggdrasil.Subscriber.Manager, name)
-      assert [] = :ets.lookup(cache, pid)
-    end
-
-    test "leaves from disconnected group when disconnected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :disconnected,
-        cache: cache
-      }
-
-      name = {:disconnected, channel}
-      pid = self()
-      :ok = Manager.join([self()], state)
-
-      assert :ok = Manager.leave([pid], state)
-      assert pid not in :pg.get_members(Yggdrasil.Subscriber.Manager, name)
-      assert [] = :ets.lookup(cache, pid)
-    end
-  end
-
-  describe "monitor/2" do
-    setup do
-      cache = :ets.new(:test, [:set])
-
-      {:ok, cache: cache}
-    end
-
-    test "monitors a process", %{cache: cache} do
-      state = %Manager{cache: cache}
-      pid = self()
-
-      assert :ok = Manager.monitor(pid, state)
-      assert [{^pid, _}] = :ets.lookup(cache, pid)
-    end
-
-    test "monitors a process once", %{cache: cache} do
-      state = %Manager{cache: cache}
-      pid = self()
-      :ok = Manager.monitor(pid, state)
-      [{^pid, reference}] = :ets.lookup(cache, pid)
-
-      assert :ok = Manager.monitor(pid, state)
-      assert [{^pid, ^reference}] = :ets.lookup(cache, pid)
-    end
-  end
-
-  describe "demonitor/2" do
-    setup do
-      cache = :ets.new(:test, [:set])
-      state = %Manager{cache: cache}
-      pid = self()
-      :ok = Manager.monitor(pid, state)
-      assert [{^pid, _}] = :ets.lookup(cache, pid)
-
-      {:ok, cache: cache, state: state}
-    end
-
-    test "demonitors a process", %{cache: cache, state: state} do
-      pid = self()
-
-      assert :ok = Manager.demonitor(pid, state)
-      assert [] = :ets.lookup(cache, pid)
-    end
-
-    test "demonitors a process once", %{cache: cache, state: state} do
-      pid = self()
-      :ok = Manager.demonitor(pid, state)
-      assert :ok = Manager.demonitor(pid, state)
-      assert [] = :ets.lookup(cache, pid)
-    end
-  end
-
-  describe "do_connected/1" do
-    setup do
-      {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
-      cache = :ets.new(:test, [:set])
-
-      state = %Manager{
-        channel: channel,
-        status: :disconnected,
-        cache: cache
-      }
-
-      :ok = Manager.join([self()], state)
-      {:ok, %{channel: channel, state: state}}
-    end
-
-    test "changes pid from disconnected to connected", %{
-      channel: channel,
-      state: state
-    } do
-      pid = self()
-      assert {:ok, %Manager{status: :connected}} = Manager.do_connected(state)
-      assert_receive {:Y_CONNECTED, ^channel}
-      name = {:disconnected, channel}
-      assert pid not in :pg.get_members(Yggdrasil.Subscriber.Manager, name)
-      name = {:connected, channel}
-      assert pid in :pg.get_members(Yggdrasil.Subscriber.Manager, name)
-    end
-  end
-
-  describe "do_disconnected/1" do
-    setup do
-      {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
-      cache = :ets.new(:test, [:set])
-
-      state = %Manager{
-        channel: channel,
-        status: :connected,
-        cache: cache
-      }
-
-      :ok = Manager.join([self()], state)
-      assert_receive {:Y_CONNECTED, ^channel}
-      {:ok, channel: channel, state: state}
-    end
-
-    test "changes pid from disconnected to connected", %{
-      channel: channel,
-      state: state
-    } do
-      pid = self()
-
-      assert {:ok, %Manager{status: :disconnected}} =
-               Manager.do_disconnected(state)
-
-      assert_receive {:Y_DISCONNECTED, ^channel}
-      name = {:connected, channel}
-      assert pid not in :pg.get_members(Yggdrasil.Subscriber.Manager, name)
-      name = {:disconnected, channel}
-      assert pid in :pg.get_members(Yggdrasil.Subscriber.Manager, name)
-    end
-  end
-
-  describe "check_subscribers/1" do
-    setup do
-      {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
-      cache = :ets.new(:test, [:set])
-
-      {:ok, channel: channel, cache: cache}
-    end
-
-    test "when there is no subscribers and is connected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :connected,
-        cache: cache
-      }
-
-      assert :stop = Manager.check_subscribers(state)
-    end
-
-    test "when there are subscribers and is connected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :connected,
-        cache: cache
-      }
-
-      assert :ok = Manager.join([self()], state)
-      assert :ok = Manager.check_subscribers(state)
-    end
-
-    test "when there is no subscribers and is disconnected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :disconnected,
-        cache: cache
-      }
-
-      assert :stop = Manager.check_subscribers(state)
-    end
-
-    test "when there are subscribers and is disconnected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :disconnected,
-        cache: cache
-      }
-
-      assert :ok = Manager.join([self()], state)
-      assert :ok = Manager.check_subscribers(state)
-    end
-  end
-
-  describe "subscribed?/3" do
-    setup do
-      {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
-      cache = :ets.new(:test, [:set])
-
-      {:ok, channel: channel, cache: cache}
-    end
-
-    test "when the subscribers are disconnected and the check is disconnected",
-         %{channel: channel, cache: cache} do
-      state = %Manager{
-        channel: channel,
-        status: :disconnected,
-        cache: cache
-      }
-
-      pid = self()
-      assert :ok = Manager.join([pid], state)
-      assert true == Manager.subscribed?(:disconnected, channel, pid)
-    end
-
-    test "when the subscribers are disconnected and the check is connected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :disconnected,
-        cache: cache
-      }
-
-      pid = self()
-      assert :ok = Manager.join([pid], state)
-      assert false == Manager.subscribed?(:connected, channel, pid)
-    end
-
-    test "when the subscribers are connected and the check is connected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :connected,
-        cache: cache
-      }
-
-      pid = self()
-      assert :ok = Manager.join([pid], state)
-      assert_receive {:Y_CONNECTED, ^channel}
-      assert true == Manager.subscribed?(:connected, channel, pid)
-    end
-
-    test "when the subscribers are connected and the check is disconnected", %{
-      channel: channel,
-      cache: cache
-    } do
-      state = %Manager{
-        channel: channel,
-        status: :connected,
-        cache: cache
-      }
-
-      pid = self()
-      assert :ok = Manager.join([pid], state)
-      assert_receive {:Y_CONNECTED, ^channel}
-      assert false == Manager.subscribed?(:disconnected, channel, pid)
-    end
-  end
-
   describe "start/stop" do
     test "starts and stops a manager" do
       {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
-      assert {:ok, pid} = Manager.start_link(channel)
+      assert {:ok, pid} = Manager.start_link(channel, self())
       assert :ok = Manager.stop(pid)
     end
   end
@@ -392,27 +14,47 @@ defmodule Yggdrasil.Subscriber.ManagerTest do
   describe "add/2" do
     setup do
       {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
+
       via_tuple = ExReg.local({Manager, channel})
-      {:ok, _} = Manager.start_link(channel, name: via_tuple)
+      first_pid = spawn(fn -> :timer.sleep(10_000) end)
+      {:ok, _} = Manager.start_link(channel, first_pid, name: via_tuple)
+
       {:ok, channel: channel}
     end
 
     test "adds a pid to subscribers", %{channel: channel} do
       pid = self()
+
       :ok = Manager.add(channel, pid)
       assert Manager.subscribed?(:disconnected, channel, pid)
+
       :ok = Manager.connected(channel)
       assert_receive {:Y_CONNECTED, ^channel}
+
       assert Manager.subscribed?(:connected, channel, pid)
     end
 
     test "does not add a subscriber twice", %{channel: channel} do
       pid = self()
+
       :ok = Manager.add(channel, pid)
       :ok = Manager.add(channel, pid)
+
       :ok = Manager.connected(channel)
       assert_receive {:Y_CONNECTED, ^channel}
+
       assert Manager.subscribed?(:connected, channel, pid)
+    end
+
+    test "monitors subscriber", %{channel: channel} do
+      pid = self()
+      :ok = Manager.add(channel, pid)
+
+      via_tuple = ExReg.local({Manager, channel})
+      %Manager{cache: cache} = :sys.get_state(via_tuple)
+
+      assert [{^pid, reference} | _] = :ets.lookup(cache, pid)
+      assert is_reference(reference)
     end
   end
 
@@ -421,69 +63,82 @@ defmodule Yggdrasil.Subscriber.ManagerTest do
       pid = self()
       {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
       via_tuple = ExReg.local({Manager, channel})
-      {:ok, _} = Manager.start_link(channel, name: via_tuple)
-      :ok = Manager.add(channel, pid)
-      {:ok, channel: channel}
+      {:ok, _} = Manager.start_link(channel, pid, name: via_tuple)
+
+      {:ok, channel: channel, pid: pid}
     end
 
     test "removes a pid from subscribers when disconnected", %{
       channel: channel
     } do
-      pid = self()
-      :ok = Manager.remove(channel, pid)
-      assert false == Manager.subscribed?(:disconnected, channel, pid)
+      :ok = Manager.remove(channel, self())
+      assert false == Manager.subscribed?(:disconnected, channel, self())
     end
 
     test "removes a pid from subscribers when connected", %{
       channel: channel
     } do
-      pid = self()
       :ok = Manager.connected(channel)
       assert_receive {:Y_CONNECTED, channel}
-      :ok = Manager.remove(channel, pid)
+
+      :ok = Manager.remove(channel, self())
       assert_receive {:Y_DISCONNECTED, channel}
-      assert false == Manager.subscribed?(:connected, channel, pid)
+
+      assert false == Manager.subscribed?(:connected, channel, self())
+    end
+
+    test "removes monitor from subscriber", %{channel: channel} do
+      dummy = spawn(fn -> :timer.sleep(10_000) end)
+      :ok = Manager.add(channel, dummy)
+
+      via_tuple = ExReg.local({Manager, channel})
+      %Manager{cache: cache} = :sys.get_state(via_tuple)
+
+      :ok = Manager.remove(channel, self())
+      assert false == Manager.subscribed?(:disconnected, channel, self())
+
+      assert [] = :ets.lookup(cache, self())
     end
   end
 
   describe "connected/1" do
     setup do
-      pid = self()
       {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
       via_tuple = ExReg.local({Manager, channel})
-      {:ok, _} = Manager.start_link(channel, name: via_tuple)
-      :ok = Manager.add(channel, pid)
+      {:ok, _} = Manager.start_link(channel, self(), name: via_tuple)
+
       {:ok, channel: channel}
     end
 
     test "connects subscribers", %{channel: channel} do
-      pid = self()
       assert :ok = Manager.connected(channel)
       assert_receive {:Y_CONNECTED, ^channel}
-      assert false == Manager.subscribed?(:disconnected, channel, pid)
-      assert true == Manager.subscribed?(:connected, channel, pid)
+
+      assert false == Manager.subscribed?(:disconnected, channel, self())
+      assert true == Manager.subscribed?(:connected, channel, self())
     end
   end
 
   describe "disconnected/1" do
     setup do
-      pid = self()
       {:ok, channel} = Yggdrasil.gen_channel(name: make_ref())
       via_tuple = ExReg.local({Manager, channel})
-      {:ok, _} = Manager.start_link(channel, name: via_tuple)
-      :ok = Manager.add(channel, pid)
+      {:ok, _} = Manager.start_link(channel, self(), name: via_tuple)
+
       :ok = Manager.connected(channel)
       assert_receive {:Y_CONNECTED, ^channel}
+
       {:ok, channel: channel}
     end
 
     test "disconnects subscribers", %{channel: channel} do
-      pid = self()
-      assert true == Manager.subscribed?(:connected, channel, pid)
+      assert true == Manager.subscribed?(:connected, channel, self())
+
       assert :ok = Manager.disconnected(channel)
       assert_receive {:Y_DISCONNECTED, ^channel}
-      assert true == Manager.subscribed?(:disconnected, channel, pid)
-      assert false == Manager.subscribed?(:connected, channel, pid)
+
+      assert true == Manager.subscribed?(:disconnected, channel, self())
+      assert false == Manager.subscribed?(:connected, channel, self())
     end
   end
 end


### PR DESCRIPTION
This PR improves how the subscription manager gets initialized. Now it uses `handle_continue/2`, instead of a different process, to initialize the first subscriber process.

![](https://media.giphy.com/media/aFTt8wvDtqKCQ/giphy.gif)